### PR TITLE
feat: Add basic zksync's solc management for zksolc compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ path = "tests/mocked.rs"
 required-features = ["full", "project-util"]
 
 [features]
-default = ["rustls"]
+default = ["rustls", "async", "svm-solc"]
 
 full = ["async", "svm-solc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ path = "tests/mocked.rs"
 required-features = ["full", "project-util"]
 
 [features]
-default = ["rustls", "async", "svm-solc"]
+default = ["rustls"]
 
 full = ["async", "svm-solc"]
 

--- a/src/zksync/artifacts/mod.rs
+++ b/src/zksync/artifacts/mod.rs
@@ -196,7 +196,7 @@ pub struct Settings {
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
     #[serde(default)]
     pub force_evmla: bool,
-
+    /// The path to the solc compiler to use along zksolc.
     pub solc: Option<std::path::PathBuf>,
 }
 

--- a/src/zksync/artifacts/mod.rs
+++ b/src/zksync/artifacts/mod.rs
@@ -196,6 +196,8 @@ pub struct Settings {
     /// A flag indicating whether to forcibly switch to the EVM legacy assembly pipeline.
     #[serde(default)]
     pub force_evmla: bool,
+
+    pub solc: Option<std::path::PathBuf>,
 }
 
 impl Settings {
@@ -235,6 +237,7 @@ impl Default for Settings {
             system_mode: false,
             force_evmla: false,
             detect_missing_libraries: false,
+            solc: None,
         }
     }
 }


### PR DESCRIPTION
* Adds the `solc` setting to zksolc to specify a path for the `solc` compiler to use.
* Auto installs and use the corresponding [zksync solc](https://github.com/matter-labs/era-solidity), given the paired solc version.

There's the caveat that we do not respect the offline setting to install solc because we would need to change how the zksolc/solc pairing is done in order to have access to the flag. Given that we will need to move all this installing logic to the `CompilerVersionManager ` trait once we do the upstream merge, I considered we could leave this unsupported for now.