### PR TITLE
fix: setup allow and include paths for non auto-detect solc

### DIFF
--- a/src/zksync/compile/project.rs
+++ b/src/zksync/compile/project.rs
@@ -41,6 +41,14 @@ impl<'a, T: ArtifactOutput> ProjectCompiler<'a, T> {
         let solc_version = solc.version()?;
         let (sources, edges) = Graph::resolve_sources(&project.paths, sources)?.into_sources();
 
+        // We need this here because paths are set on this method and
+        // zksolc inherits them later from solc
+        let solc = project.configure_solc_with_version(
+            solc,
+            Some(solc_version.clone()),
+            edges.include_paths().clone(),
+        );
+
         let sources_by_version = BTreeMap::from([(solc, (solc_version, sources))]);
         let sources = CompilerSources::Sequential(sources_by_version);
 


### PR DESCRIPTION
Right now (to be changed to something more sane in the future) we inherit some settings from `solc` when setting up `zksolc`, including for example the needed `allow_paths`. The settings needed were only correctly configured on the auto_detect path and not when a solc version is being specified. 