### PR TITLE
fix: avoid passing `--solc` in yul mode

### DIFF
--- a/src/zksync/compile/mod.rs
+++ b/src/zksync/compile/mod.rs
@@ -233,10 +233,13 @@ impl ZkSolc {
             cmd.arg("--detect-missing-libraries");
         }
 
-        if let Some(solc) = &input.settings.solc {
-            cmd.arg("--solc").arg(solc);
-        } else if let Some(solc) = &self.solc {
-            cmd.arg("--solc").arg(solc);
+        // don't pass solc argument in yul mode (avoid verification)
+        if !input.is_yul() {
+            if let Some(solc) = &input.settings.solc {
+                cmd.arg("--solc").arg(solc);
+            } else if let Some(solc) = &self.solc {
+                cmd.arg("--solc").arg(solc);
+            }
         }
 
         cmd.args(&self.args).arg("--standard-json");

--- a/src/zksync/compile/output/mod.rs
+++ b/src/zksync/compile/output/mod.rs
@@ -92,6 +92,10 @@ impl ProjectCompileOutput {
         &self.compiler_output
     }
 
+    pub fn into_output(self) -> AggregatedCompilerOutput {
+        self.compiler_output
+    }
+
     /// Finds the artifact with matching path and name
     pub fn find(
         &self,


### PR DESCRIPTION
This is to avoid `zksolc` erroring out needing the latest `solc` version (for yul checking). 
If we don't pass the `--solc` argument then the yul sources are compiled normally.
Providing the compiler with multiple sources in the same invocation seems to also work, unlike with plain `solc`.