### PR TITLE
feat: remove avoid contracts

### DIFF
--- a/crates/compilers/Cargo.toml
+++ b/crates/compilers/Cargo.toml
@@ -52,7 +52,6 @@ svm-builds = { package = "svm-rs-builds", version = "0.5", default-features = fa
 sha2 = { version = "0.10", default-features = false, optional = true }
 
 # zksync
-globset.workspace = true
 reqwest = { version = "0.12", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -113,7 +113,6 @@ pub struct Project<C: Compiler = MultiCompiler, T: ArtifactOutput = Configurable
     pub zksync_zksolc: ZkSolc,
     pub zksync_zksolc_config: ZkSolcConfig,
     pub zksync_artifacts: ZkArtifactOutput,
-    pub zksync_avoid_contracts: Option<Vec<globset::GlobMatcher>>,
 }
 
 impl Project {
@@ -498,7 +497,6 @@ pub struct ProjectBuilder<C: Compiler = MultiCompiler, T: ArtifactOutput = Confi
     /// Where to find zksolc
     zksync_zksolc: Option<ZkSolc>,
     zksync_zksolc_config: Option<ZkSolcConfig>,
-    zksync_avoid_contracts: Option<Vec<globset::GlobMatcher>>,
 }
 
 impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
@@ -522,7 +520,6 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
 
             zksync_zksolc: None,
             zksync_zksolc_config: None,
-            zksync_avoid_contracts: None,
         }
     }
 
@@ -678,7 +675,6 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
 
             zksync_zksolc,
             zksync_zksolc_config,
-            zksync_avoid_contracts,
             ..
         } = self;
         ProjectBuilder {
@@ -699,7 +695,6 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
 
             zksync_zksolc,
             zksync_zksolc_config,
-            zksync_avoid_contracts,
         }
     }
 
@@ -722,7 +717,6 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
 
             zksync_zksolc,
             zksync_zksolc_config,
-            zksync_avoid_contracts,
         } = self;
 
         let mut paths = paths.map(Ok).unwrap_or_else(ProjectPathsConfig::current_hardhat)?;
@@ -757,7 +751,6 @@ impl<C: Compiler, T: ArtifactOutput> ProjectBuilder<C, T> {
             zksync_zksolc,
             zksync_zksolc_config,
             zksync_artifacts,
-            zksync_avoid_contracts,
         })
     }
 }

--- a/crates/compilers/src/zksync/compile/project.rs
+++ b/crates/compilers/src/zksync/compile/project.rs
@@ -14,7 +14,7 @@ use crate::{
         cache::ArtifactsCache,
         compile::output::{AggregatedCompilerOutput, ProjectCompileOutput},
     },
-    FilteredSources, Graph, Project, Source, Sources,
+    FilteredSources, Graph, Project, Sources,
 };
 use foundry_compilers_artifacts::{zksolc::CompilerOutput, SolcLanguage};
 use semver::Version;
@@ -41,17 +41,7 @@ impl<'a, T: ArtifactOutput> ProjectCompiler<'a, T> {
     /// Create a new `ProjectCompiler` to bootstrap the compilation process of the project's
     /// sources.
     pub fn new(project: &'a Project<SolcCompiler, T>) -> Result<Self> {
-        let sources = match project.zksync_avoid_contracts {
-            Some(ref contracts_to_avoid) => Source::read_all(
-                project
-                    .paths
-                    .input_files()
-                    .into_iter()
-                    .filter(|p| !contracts_to_avoid.iter().any(|c| c.is_match(p))),
-            )?,
-            None => project.paths.read_input_files()?,
-        };
-        Self::with_sources(project, sources)
+        Self::with_sources(project, project.paths.read_input_files()?)
     }
 
     /// Bootstraps the compilation process by resolving the dependency graph of all sources and the


### PR DESCRIPTION
Remove avoid contracts from foundry compilers in favor of implementing the filter in foundry itself (as it is done with all other filters)

see: https://github.com/matter-labs/foundry-zksync/pull/456