### PR TITLE
fix: use lockfile to prevent parallel downloads

### DIFF
--- a/crates/compilers/Cargo.toml
+++ b/crates/compilers/Cargo.toml
@@ -40,6 +40,7 @@ derivative = "2.2"
 home = "0.5"
 dirs = "5.0"
 itertools = "0.13"
+fd-lock = "4.0.2"
 
 # project-util
 tempfile = { version = "3.9", optional = true }


### PR DESCRIPTION
Currently concurrent tests can trigger the behavior where the zksolc is being downloaded in parallel causing access issues. 
This PR fixes it by using file locking.