### PR TITLE
fix: add installer lock to solc and do not rewrite a dowloaded compiler binary

### DIFF
--- a/crates/artifacts/zksolc/src/error.rs
+++ b/crates/artifacts/zksolc/src/error.rs
@@ -1,10 +1,7 @@
 use foundry_compilers_artifacts_solc::error::{Severity, SourceLocation};
 
 use foundry_compilers_artifacts_solc::serde_helpers;
-use serde::{
-    de::{self, Deserializer},
-    Deserialize, Serialize,
-};
+use serde::{Deserialize, Serialize};
 use std::{fmt, ops::Range};
 use yansi::{Color, Style};
 

--- a/crates/compilers/Cargo.toml
+++ b/crates/compilers/Cargo.toml
@@ -53,6 +53,7 @@ sha2 = { version = "0.10", default-features = false, optional = true }
 
 # zksync
 reqwest = { version = "0.12", default-features = false, optional = true }
+fs4 = "0.8"
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/compilers/Cargo.toml
+++ b/crates/compilers/Cargo.toml
@@ -40,7 +40,6 @@ derivative = "2.2"
 home = "0.5"
 dirs = "5.0"
 itertools = "0.13"
-fd-lock = "4.0.2"
 
 # project-util
 tempfile = { version = "3.9", optional = true }

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -400,7 +400,8 @@ fn compiler_blocking_install(
     label: &str,
 ) -> Result<PathBuf> {
     use foundry_compilers_core::utils::RuntimeOrHandle;
-    trace!("blocking installing {label}");
+    info!("blocking installing {label}");
+    //trace!("blocking installing {label}");
     // An async block is used because the underlying `reqwest::blocking::Client` does not behave
     // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
     RuntimeOrHandle::new().block_on(async {
@@ -416,18 +417,22 @@ fn compiler_blocking_install(
                 .bytes()
                 .await
                 .map_err(|e| SolcError::msg(format!("failed to download {label} file: {e}")))?;
-            trace!("downloaded {label}");
+            info!("downloaded {label}");
+            //trace!("downloaded {label}");
 
             // lock file to indicate that installation of this compiler version will be in progress.
             // wait until lock file is released, possibly by another parallel thread trying to install the
             // same compiler version.
+            info!("try to get lock for {label}");
             let _lock = try_lock_file(lock_path)?;
+            info!("got lock for {label}");
 
             // Only write to file if it is not there. The check is doneafter adquiring the lock
             // to ensure the thread remains blocked until the required compiler is
             // fully installed
             if !compiler_path.exists() {
-                trace!("creating binary for {label}");
+                info!("creating binary for {label}");
+                //trace!("creating binary for {label}");
                 let mut output_file = File::create(&compiler_path).map_err(|e| {
                     SolcError::msg(format!("Failed to create output {label} file: {e}"))
                 })?;
@@ -440,7 +445,7 @@ fn compiler_blocking_install(
                     SolcError::msg(format!("Failed to set {label} permissions: {e}"))
                 })?;
             } else {
-                trace!("found binary for {label}");
+                info!("found binary for {label}");
             }
         } else {
             return Err(SolcError::msg(format!(
@@ -448,7 +453,7 @@ fn compiler_blocking_install(
                 response.status()
             )));
         }
-        trace!("{label} instalation completed");
+        info!("{label} instalation completed");
         Ok(compiler_path)
     })
 }

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -237,7 +237,6 @@ impl ZkSolc {
     /// Invokes `zksolc --version` and parses the output as a SemVer [`Version`], stripping the
     /// pre-release and build metadata.
     pub fn version_short(&self) -> Result<Version> {
-        println!("version short");
         let version = self.version()?;
         Ok(Version::new(version.major, version.minor, version.patch))
     }
@@ -245,7 +244,6 @@ impl ZkSolc {
     /// Invokes `zksolc --version` and parses the output as a SemVer [`Version`].
     #[instrument(level = "debug", skip_all)]
     pub fn version(&self) -> Result<Version> {
-        println!("version");
         let mut cmd = Command::new(&self.zksolc);
         cmd.arg("--version").stdin(Stdio::piped()).stderr(Stdio::piped()).stdout(Stdio::piped());
         debug!(?cmd, "getting ZkSolc version");
@@ -283,73 +281,24 @@ impl ZkSolc {
     }
 
     /// Install zksolc version and block the thread
-    // TODO: Maybe this (and the whole module) goes behind a zksync feature installed
     #[cfg(feature = "async")]
     pub fn blocking_install(version: &Version) -> Result<Self> {
-        use foundry_compilers_core::utils::RuntimeOrHandle;
-        println!("block install started");
+        let os = get_operating_system()?;
+        let os_namespace = os.get_download_uri();
+        let download_url = format!(
+            "https://github.com/matter-labs/zksolc-bin/releases/download/v{version}/zksolc-{os_namespace}-v{version}",
+        );
 
-        trace!("blocking installing zksolc version \"{}\"", version);
-        // TODO: Evaluate report support
-        //crate::report::solc_installation_start(version);
-        // An async block is used because the underlying `reqwest::blocking::Client` does not behave
-        // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
-        let install = RuntimeOrHandle::new().block_on(async {
-            let os = get_operating_system()?;
-            let download_uri = os.get_download_uri();
-            let full_download_url = format!(
-                "https://github.com/matter-labs/zksolc-bin/releases/download/v{version}/zksolc-{download_uri}-v{version}",
-            );
+        let compilers_dir = Self::compilers_dir()?;
+        if !compilers_dir.exists() {
+            create_dir_all(compilers_dir)
+                .map_err(|e| SolcError::msg(format!("Could not create compilers path: {e}")))?;
+        }
+        let compiler_path = Self::compiler_path(version)?;
+        let lock_path = lock_file_path("zksolc", &version.to_string());
 
-            let compiler_path = Self::compiler_path(version)?;
-
-            let client = reqwest::Client::new();
-            let response = client
-                .get(full_download_url)
-                .send()
-                .await
-                .map_err(|e| SolcError::msg(format!("Failed to download file: {e}")))?;
-
-            if response.status().is_success() {
-                let compilers_dir = Self::compilers_dir()?;
-                if !compilers_dir.exists() {
-                    create_dir_all(compilers_dir).map_err(|e| {
-                        SolcError::msg(format!("Could not create compilers path: {e}"))
-                    })?;
-                }
-                let content = response
-                    .bytes()
-                    .await
-                    .map_err(|e| SolcError::msg(format!("failed to download file: {e}")))?;
-
-                // lock file to indicate that installation of this compiler version will be in progress.
-                let lock_path = lock_file_path("zksolc", &version.to_string());
-                // wait until lock file is released, possibly by another parallel thread trying to install the
-                // same compiler version.
-                let _lock = try_lock_file(lock_path)?;
-
-                // Only write to file if it is not there
-                if !compiler_path.exists() {
-                    let mut output_file = File::create(&compiler_path)
-                        .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
-
-                    output_file.write_all(&content).map_err(|e| {
-                        SolcError::msg(format!("Failed to write the downloaded file: {e}"))
-                    })?;
-
-                    set_permissions(&compiler_path, PermissionsExt::from_mode(0o755)).map_err(
-                        |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
-                    )?;
-                }
-
-            } else {
-                return Err(SolcError::msg(format!(
-                    "Failed to download file: status code {}",
-                    response.status()
-                )));
-            }
-            Ok(compiler_path)
-        });
+        let label = format!("zksolc-{version}");
+        let install = compiler_blocking_install(compiler_path, lock_path, &download_url, &label);
 
         match install {
             Ok(path) => {
@@ -363,71 +312,25 @@ impl ZkSolc {
         }
     }
 
+    /// Install zksync solc version and block the thread
     #[cfg(feature = "async")]
     pub fn solc_blocking_install(version_str: &str) -> Result<PathBuf> {
-        use crate::utils::RuntimeOrHandle;
+        let os = get_operating_system()?;
+        let solc_os_namespace = os.get_solc_prefix();
+        let download_url = format!(
+            "https://github.com/matter-labs/era-solidity/releases/download/{version_str}-{ZKSYNC_SOLC_RELEASE}/{solc_os_namespace}{version_str}-{ZKSYNC_SOLC_RELEASE}",
+        );
 
-        trace!("blocking installing solc version \"{}\"", version_str);
-        // TODO: Evaluate report support
-        //crate::report::solc_installation_start(version);
-        // An async block is used because the underlying `reqwest::blocking::Client` does not behave
-        // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
-        RuntimeOrHandle::new().block_on(async {
-            let os = get_operating_system()?;
-            let solc_prefix = os.get_solc_prefix();
-            let full_download_url = format!(
-                "https://github.com/matter-labs/era-solidity/releases/download/{version_str}-{ZKSYNC_SOLC_RELEASE}/{solc_prefix}{version_str}-{ZKSYNC_SOLC_RELEASE}",
-            );
+        let compilers_dir = Self::compilers_dir()?;
+        if !compilers_dir.exists() {
+            create_dir_all(compilers_dir)
+                .map_err(|e| SolcError::msg(format!("Could not create compilers path: {e}")))?;
+        }
+        let solc_path = Self::solc_path(version_str)?;
+        let lock_path = lock_file_path("solc", version_str);
 
-            let solc_path = Self::solc_path(version_str)?;
-
-            let client = reqwest::Client::new();
-            let response = client
-                .get(full_download_url)
-                .send()
-                .await
-                .map_err(|e| SolcError::msg(format!("Failed to download file: {e}")))?;
-
-            if response.status().is_success() {
-                let compilers_dir = Self::compilers_dir()?;
-                if !compilers_dir.exists() {
-                    create_dir_all(compilers_dir).map_err(|e| {
-                        SolcError::msg(format!("Could not create compilers path: {e}"))
-                    })?;
-                }
-
-                let content = response
-                    .bytes()
-                    .await
-                    .map_err(|e| SolcError::msg(format!("failed to download file: {e}")))?;
-
-                // lock file to indicate that installation of this compiler version will be in progress.
-                let lock_path = lock_file_path("solc", version_str);
-                // wait until lock file is released, possibly by another parallel thread trying to install the
-                // same compiler version.
-                let _lock = try_lock_file(lock_path)?;
-
-                // Only write to file if it is not there
-                if !solc_path.exists() {
-                    let mut output_file = File::create(&solc_path)
-                        .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
-
-                    output_file.write_all(&content).map_err(|e| {
-                        SolcError::msg(format!("Failed to write the downloaded file: {e}"))
-                    })?;
-
-                    set_permissions(&solc_path, PermissionsExt::from_mode(0o755)).map_err(
-                        |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
-                    )?;
-                }
-            } else {
-                return Err(SolcError::msg(format!(
-                    "Failed to download file: status code {}",
-                    response.status()
-                )));
-            }
-            Ok(solc_path)
-        })
+        let label = format!("solc-{version_str}");
+        compiler_blocking_install(solc_path, lock_path, &download_url, &label)
     }
 
     pub fn find_installed_version(version: &Version) -> Result<Option<Self>> {
@@ -490,10 +393,69 @@ impl<T: Into<PathBuf>> From<T> for ZkSolc {
     }
 }
 
+fn compiler_blocking_install(
+    compiler_path: PathBuf,
+    lock_path: PathBuf,
+    download_url: &str,
+    label: &str,
+) -> Result<PathBuf> {
+    use foundry_compilers_core::utils::RuntimeOrHandle;
+    trace!("blocking installing {label}");
+    // An async block is used because the underlying `reqwest::blocking::Client` does not behave
+    // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
+    RuntimeOrHandle::new().block_on(async {
+        let client = reqwest::Client::new();
+        let response = client
+            .get(download_url)
+            .send()
+            .await
+            .map_err(|e| SolcError::msg(format!("Failed to download {label} file: {e}")))?;
+
+        if response.status().is_success() {
+            let content = response
+                .bytes()
+                .await
+                .map_err(|e| SolcError::msg(format!("failed to download {label} file: {e}")))?;
+            trace!("downloaded {label}");
+
+            // lock file to indicate that installation of this compiler version will be in progress.
+            // wait until lock file is released, possibly by another parallel thread trying to install the
+            // same compiler version.
+            let _lock = try_lock_file(lock_path)?;
+
+            // Only write to file if it is not there. The check is doneafter adquiring the lock
+            // to ensure the thread remains blocked until the required compiler is
+            // fully installed
+            if !compiler_path.exists() {
+                trace!("creating binary for {label}");
+                let mut output_file = File::create(&compiler_path).map_err(|e| {
+                    SolcError::msg(format!("Failed to create output {label} file: {e}"))
+                })?;
+
+                output_file.write_all(&content).map_err(|e| {
+                    SolcError::msg(format!("Failed to write the downloaded {label} file: {e}"))
+                })?;
+
+                set_permissions(&compiler_path, PermissionsExt::from_mode(0o755)).map_err(|e| {
+                    SolcError::msg(format!("Failed to set {label} permissions: {e}"))
+                })?;
+            } else {
+                trace!("found binary for {label}");
+            }
+        } else {
+            return Err(SolcError::msg(format!(
+                "Failed to download {label} file: status code {}",
+                response.status()
+            )));
+        }
+        trace!("{label} instalation completed");
+        Ok(compiler_path)
+    })
+}
+
 /// Creates the file and locks it exclusively, this will block if the file is currently locked
 fn try_lock_file(lock_path: PathBuf) -> Result<LockFile> {
     use fs4::FileExt;
-    println!("Trying to take the lock");
     let _lock_file = std::fs::OpenOptions::new()
         .create(true)
         .truncate(true)
@@ -502,7 +464,6 @@ fn try_lock_file(lock_path: PathBuf) -> Result<LockFile> {
         .open(&lock_path)
         .map_err(|_| SolcError::msg("Error creating lock file"))?;
     _lock_file.lock_exclusive().map_err(|_| SolcError::msg("Error taking the lock"))?;
-    println!("Got the lock");
     Ok(LockFile { lock_path, _lock_file })
 }
 

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -400,7 +400,7 @@ fn compiler_blocking_install(
     label: &str,
 ) -> Result<PathBuf> {
     use foundry_compilers_core::utils::RuntimeOrHandle;
-    println!("blocking installing {label}");
+    warn!("blocking installing {label}");
     //trace!("blocking installing {label}");
     // An async block is used because the underlying `reqwest::blocking::Client` does not behave
     // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
@@ -417,21 +417,21 @@ fn compiler_blocking_install(
                 .bytes()
                 .await
                 .map_err(|e| SolcError::msg(format!("failed to download {label} file: {e}")))?;
-            println!("downloaded {label}");
+            warn!("downloaded {label}");
             //trace!("downloaded {label}");
 
             // lock file to indicate that installation of this compiler version will be in progress.
             // wait until lock file is released, possibly by another parallel thread trying to install the
             // same compiler version.
-            println!("try to get lock for {label}");
+            warn!("try to get lock for {label}");
             let _lock = try_lock_file(lock_path)?;
-            println!("got lock for {label}");
+            warn!("got lock for {label}");
 
             // Only write to file if it is not there. The check is doneafter adquiring the lock
             // to ensure the thread remains blocked until the required compiler is
             // fully installed
             if !compiler_path.exists() {
-                println!("creating binary for {label}");
+                warn!("creating binary for {label}");
                 //trace!("creating binary for {label}");
                 let mut output_file = File::create(&compiler_path).map_err(|e| {
                     SolcError::msg(format!("Failed to create output {label} file: {e}"))
@@ -445,7 +445,7 @@ fn compiler_blocking_install(
                     SolcError::msg(format!("Failed to set {label} permissions: {e}"))
                 })?;
             } else {
-                println!("found binary for {label}");
+                warn!("found binary for {label}");
             }
         } else {
             return Err(SolcError::msg(format!(
@@ -453,7 +453,7 @@ fn compiler_blocking_install(
                 response.status()
             )));
         }
-        println!("{label} instalation completed");
+        warn!("{label} instalation completed");
         Ok(compiler_path)
     })
 }

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -328,16 +328,20 @@ impl ZkSolc {
                 // same compiler version.
                 let _lock = try_lock_file(lock_path)?;
 
-                let mut output_file = File::create(&compiler_path)
-                    .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
+                // Only write to file if it is not there
+                if !compiler_path.exists() {
+                    let mut output_file = File::create(&compiler_path)
+                        .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
 
-                output_file.write_all(&content).map_err(|e| {
-                    SolcError::msg(format!("Failed to write the downloaded file: {e}"))
-                })?;
+                    output_file.write_all(&content).map_err(|e| {
+                        SolcError::msg(format!("Failed to write the downloaded file: {e}"))
+                    })?;
 
-                set_permissions(&compiler_path, PermissionsExt::from_mode(0o755)).map_err(
-                    |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
-                )?;
+                    set_permissions(&compiler_path, PermissionsExt::from_mode(0o755)).map_err(
+                        |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
+                    )?;
+                }
+
             } else {
                 return Err(SolcError::msg(format!(
                     "Failed to download file: status code {}",
@@ -403,16 +407,19 @@ impl ZkSolc {
                 // same compiler version.
                 let _lock = try_lock_file(lock_path)?;
 
-                let mut output_file = File::create(&solc_path)
-                    .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
+                // Only write to file if it is not there
+                if !solc_path.exists() {
+                    let mut output_file = File::create(&solc_path)
+                        .map_err(|e| SolcError::msg(format!("Failed to create output file: {e}")))?;
 
-                output_file.write_all(&content).map_err(|e| {
-                    SolcError::msg(format!("Failed to write the downloaded file: {e}"))
-                })?;
+                    output_file.write_all(&content).map_err(|e| {
+                        SolcError::msg(format!("Failed to write the downloaded file: {e}"))
+                    })?;
 
-                set_permissions(&solc_path, PermissionsExt::from_mode(0o755)).map_err(
-                    |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
-                )?;
+                    set_permissions(&solc_path, PermissionsExt::from_mode(0o755)).map_err(
+                        |e| SolcError::msg(format!("Failed to set zksync compiler permissions: {e}")),
+                    )?;
+                }
             } else {
                 return Err(SolcError::msg(format!(
                     "Failed to download file: status code {}",

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -15,7 +15,7 @@ use std::{
 #[cfg(feature = "async")]
 use std::{
     fs::{self, create_dir_all, set_permissions, File},
-    io::write,
+    io::Write,
 };
 
 #[cfg(target_family = "unix")]

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -400,7 +400,7 @@ fn compiler_blocking_install(
     label: &str,
 ) -> Result<PathBuf> {
     use foundry_compilers_core::utils::RuntimeOrHandle;
-    warn!("blocking installing {label}");
+    trace!("blocking installing {label}");
     //trace!("blocking installing {label}");
     // An async block is used because the underlying `reqwest::blocking::Client` does not behave
     // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
@@ -417,21 +417,20 @@ fn compiler_blocking_install(
                 .bytes()
                 .await
                 .map_err(|e| SolcError::msg(format!("failed to download {label} file: {e}")))?;
-            warn!("downloaded {label}");
-            //trace!("downloaded {label}");
+            trace!("downloaded {label}");
 
             // lock file to indicate that installation of this compiler version will be in progress.
             // wait until lock file is released, possibly by another parallel thread trying to install the
             // same compiler version.
-            warn!("try to get lock for {label}");
+            trace!("try to get lock for {label}");
             let _lock = try_lock_file(lock_path)?;
-            warn!("got lock for {label}");
+            trace!("got lock for {label}");
 
             // Only write to file if it is not there. The check is doneafter adquiring the lock
             // to ensure the thread remains blocked until the required compiler is
             // fully installed
             if !compiler_path.exists() {
-                warn!("creating binary for {label}");
+                trace!("creating binary for {label}");
                 //trace!("creating binary for {label}");
                 let mut output_file = File::create(&compiler_path).map_err(|e| {
                     SolcError::msg(format!("Failed to create output {label} file: {e}"))
@@ -445,7 +444,7 @@ fn compiler_blocking_install(
                     SolcError::msg(format!("Failed to set {label} permissions: {e}"))
                 })?;
             } else {
-                warn!("found binary for {label}");
+                trace!("found binary for {label}");
             }
         } else {
             return Err(SolcError::msg(format!(
@@ -453,7 +452,7 @@ fn compiler_blocking_install(
                 response.status()
             )));
         }
-        warn!("{label} instalation completed");
+        trace!("{label} instalation completed");
         Ok(compiler_path)
     })
 }

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -287,6 +287,8 @@ impl ZkSolc {
     // TODO: Maybe this (and the whole module) goes behind a zksync feature installed
     #[cfg(feature = "async")]
     pub fn blocking_install(version: &Version) -> Result<Self> {
+        #[cfg(test)]
+        take_solc_installer_lock!(_lock);
         use crate::utils::RuntimeOrHandle;
 
         trace!("blocking installing solc version \"{}\"", version);

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -400,7 +400,7 @@ fn compiler_blocking_install(
     label: &str,
 ) -> Result<PathBuf> {
     use foundry_compilers_core::utils::RuntimeOrHandle;
-    info!("blocking installing {label}");
+    println!("blocking installing {label}");
     //trace!("blocking installing {label}");
     // An async block is used because the underlying `reqwest::blocking::Client` does not behave
     // well inside of a Tokio runtime. See: https://github.com/seanmonstar/reqwest/issues/1017
@@ -417,21 +417,21 @@ fn compiler_blocking_install(
                 .bytes()
                 .await
                 .map_err(|e| SolcError::msg(format!("failed to download {label} file: {e}")))?;
-            info!("downloaded {label}");
+            println!("downloaded {label}");
             //trace!("downloaded {label}");
 
             // lock file to indicate that installation of this compiler version will be in progress.
             // wait until lock file is released, possibly by another parallel thread trying to install the
             // same compiler version.
-            info!("try to get lock for {label}");
+            println!("try to get lock for {label}");
             let _lock = try_lock_file(lock_path)?;
-            info!("got lock for {label}");
+            println!("got lock for {label}");
 
             // Only write to file if it is not there. The check is doneafter adquiring the lock
             // to ensure the thread remains blocked until the required compiler is
             // fully installed
             if !compiler_path.exists() {
-                info!("creating binary for {label}");
+                println!("creating binary for {label}");
                 //trace!("creating binary for {label}");
                 let mut output_file = File::create(&compiler_path).map_err(|e| {
                     SolcError::msg(format!("Failed to create output {label} file: {e}"))
@@ -445,7 +445,7 @@ fn compiler_blocking_install(
                     SolcError::msg(format!("Failed to set {label} permissions: {e}"))
                 })?;
             } else {
-                info!("found binary for {label}");
+                println!("found binary for {label}");
             }
         } else {
             return Err(SolcError::msg(format!(
@@ -453,7 +453,7 @@ fn compiler_blocking_install(
                 response.status()
             )));
         }
-        info!("{label} instalation completed");
+        println!("{label} instalation completed");
         Ok(compiler_path)
     })
 }

--- a/crates/compilers/src/zksync/artifact_output/mod.rs
+++ b/crates/compilers/src/zksync/artifact_output/mod.rs
@@ -80,7 +80,7 @@ pub fn artifacts_into_artifacts(
 ) -> impl Iterator<Item = (ArtifactId, ZkContractArtifact)> {
     artifacts.0.into_iter().flat_map(|(file, contract_artifacts)| {
         contract_artifacts.into_iter().flat_map(move |(_contract_name, artifacts)| {
-            let source = PathBuf::from(file.clone());
+            let source = file.clone();
             artifacts.into_iter().filter_map(move |artifact| {
                 contract_name(&artifact.file).map(|name| {
                     (


### PR DESCRIPTION
We were having several race conditions on tests where compiler files were either written by two threads at the same time or written by one thread while the file was being run as an executable.
This tries to solve this by also adding a lock to solc downloads and not rewritting a compiler file if it has already been created.