### PR TITLE
fix: Cli settings not passing correctly to ZK

### DIFF
--- a/.github/workflows/zksync-ci.yml
+++ b/.github/workflows/zksync-ci.yml
@@ -8,8 +8,8 @@ on:
         branches:
             - 'zksync-v**'
 concurrency:
-    cancel-in-progress: true
-    group: ${{github.workflow}}-${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
     CARGO_TERM_COLOR: always
@@ -62,18 +62,17 @@ jobs:
     cargo-test:
         name: cargo-test
         runs-on: ubuntu-latest
-  
+        timeout-minutes: 30
         steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-          with:
-            submodules: recursive
-            ref: ${{ github.event.pull_request.head.sha }}
-  
-        - name: Install Rust
-          uses: actions-rust-lang/setup-rust-toolchain@v1
-
-        - name: Run tests
-          env:
-            RUST_BACKTRACE: full
-          run: cargo test
+          - uses: actions/checkout@v4
+            with:
+              submodules: recursive
+              ref: ${{ github.event.pull_request.head.sha }}
+          - uses: actions-rust-lang/setup-rust-toolchain@v1
+          - uses: Swatinem/rust-cache@v2
+            with:
+              cache-on-failure: true
+          - name: Run tests
+            run: cargo test --all-features
+            env:
+              RUST_BACKTRACE: full

--- a/.github/workflows/zksync-ci.yml
+++ b/.github/workflows/zksync-ci.yml
@@ -47,11 +47,17 @@ jobs:
     fmt:
         name: fmt
         runs-on: ubuntu-latest
-        timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@clippy
-            - run: cargo fmt --all --check
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Install Rust
+              uses: dtolnay/rust-toolchain@stable
+              with:
+                components: rustfmt
+
+            - name: Run rustfmt
+              run: cargo fmt -- --check
     
     cargo-test:
         name: cargo-test

--- a/.github/workflows/zksync-ci.yml
+++ b/.github/workflows/zksync-ci.yml
@@ -73,6 +73,6 @@ jobs:
             with:
               cache-on-failure: true
           - name: Run tests
-            run: cargo test --all-features
+            run: cargo test zk
             env:
               RUST_BACKTRACE: full

--- a/.github/workflows/zksync-ci.yml
+++ b/.github/workflows/zksync-ci.yml
@@ -17,7 +17,7 @@ env:
 jobs:
     doctests:
         name: doc tests
-        runs-on: ubuntu-22.04-github-hosted-16core
+        runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
 
     fmt:
         name: fmt
-        runs-on: ubuntu-22.04-github-hosted-16core
+        runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     
     cargo-test:
         name: cargo-test
-        runs-on: ubuntu-22.04-github-hosted-16core
+        runs-on: ubuntu-latest
   
         steps:
         - name: Checkout code

--- a/.github/workflows/zksync-ci.yml
+++ b/.github/workflows/zksync-ci.yml
@@ -22,8 +22,6 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@nightly
-              with:
-                toolchain: nightly-2024-04-28
             - uses: Swatinem/rust-cache@v2
               with:
                 cache-on-failure: true
@@ -52,10 +50,7 @@ jobs:
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@nightly
-              with:
-                  toolchain: nightly-2024-04-28
-                  components: rustfmt
+            - uses: dtolnay/rust-toolchain@clippy
             - run: cargo fmt --all --check
     
     cargo-test:
@@ -71,8 +66,6 @@ jobs:
   
         - name: Install Rust
           uses: actions-rust-lang/setup-rust-toolchain@v1
-          with:
-            toolchain: nightly-2024-04-28
 
         - name: Run tests
           env:

--- a/crates/compilers/src/compilers/zksolc/input.rs
+++ b/crates/compilers/src/compilers/zksolc/input.rs
@@ -1,11 +1,13 @@
-use super::settings::ZkSolcSettings;
-use crate::compilers::{solc::SolcLanguage, CompilerInput};
+use super::{settings::ZkSolcSettings, ZkSettings};
+use crate::{
+    compilers::{solc::SolcLanguage, CompilerInput},
+    solc,
+};
 use foundry_compilers_artifacts::{remappings::Remapping, solc::serde_helpers, Source, Sources};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
-    collections::BTreeSet,
     path::{Path, PathBuf},
 };
 
@@ -13,10 +15,8 @@ use std::{
 pub struct ZkSolcVersionedInput {
     #[serde(flatten)]
     pub input: ZkSolcInput,
-    pub allow_paths: BTreeSet<PathBuf>,
-    pub base_path: Option<PathBuf>,
-    pub include_paths: BTreeSet<PathBuf>,
     pub solc_version: Version,
+    pub cli_settings: solc::CliSettings,
 }
 
 impl CompilerInput for ZkSolcVersionedInput {
@@ -32,15 +32,10 @@ impl CompilerInput for ZkSolcVersionedInput {
         language: Self::Language,
         version: Version,
     ) -> Self {
+        let ZkSolcSettings { settings, cli_settings } = settings;
         let input = ZkSolcInput { language, sources, settings }.sanitized(&version);
 
-        Self {
-            solc_version: version,
-            input,
-            base_path: None,
-            include_paths: Default::default(),
-            allow_paths: Default::default(),
-        }
+        Self { solc_version: version, input, cli_settings }
     }
 
     fn language(&self) -> Self::Language {
@@ -73,7 +68,7 @@ impl CompilerInput for ZkSolcVersionedInput {
 pub struct ZkSolcInput {
     pub language: SolcLanguage,
     pub sources: Sources,
-    pub settings: ZkSolcSettings,
+    pub settings: ZkSettings,
 }
 
 /// Default `language` field is set to `"Solidity"`.
@@ -82,7 +77,7 @@ impl Default for ZkSolcInput {
         Self {
             language: SolcLanguage::Solidity,
             sources: Sources::default(),
-            settings: ZkSolcSettings::default(),
+            settings: ZkSettings::default(),
         }
     }
 }
@@ -133,11 +128,11 @@ pub struct StandardJsonCompilerInput {
     pub language: SolcLanguage,
     #[serde(with = "serde_helpers::tuple_vec_map")]
     pub sources: Vec<(PathBuf, Source)>,
-    pub settings: ZkSolcSettings,
+    pub settings: ZkSettings,
 }
 
 impl StandardJsonCompilerInput {
-    pub fn new(sources: Vec<(PathBuf, Source)>, settings: ZkSolcSettings) -> Self {
+    pub fn new(sources: Vec<(PathBuf, Source)>, settings: ZkSettings) -> Self {
         Self { language: SolcLanguage::Solidity, sources, settings }
     }
 }

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -33,6 +33,7 @@ use std::os::unix::fs::PermissionsExt;
 
 pub mod input;
 pub mod settings;
+pub use settings::ZkSettings;
 pub use settings::ZkSolcSettings;
 
 pub const ZKSOLC: &str = "zksolc";
@@ -178,9 +179,9 @@ impl ZkSolcCompiler {
             }
         }
 
-        zksolc.base_path.clone_from(&input.base_path);
-        zksolc.allow_paths.clone_from(&input.allow_paths);
-        zksolc.include_paths.clone_from(&input.include_paths);
+        zksolc.base_path.clone_from(&input.cli_settings.base_path);
+        zksolc.allow_paths.clone_from(&input.cli_settings.allow_paths);
+        zksolc.include_paths.clone_from(&input.cli_settings.include_paths);
 
         zksolc.compile(&input.input)
     }
@@ -296,6 +297,7 @@ impl ZkSolc {
     pub fn compile_output(&self, input: &ZkSolcInput) -> Result<Vec<u8>> {
         let mut cmd = Command::new(&self.zksolc);
 
+        println!("ALLOW PATHS: {:?}", self.allow_paths);
         if !self.allow_paths.is_empty() {
             cmd.arg("--allow-paths");
             cmd.arg(self.allow_paths.iter().map(|p| p.display()).join(","));

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -297,7 +297,6 @@ impl ZkSolc {
     pub fn compile_output(&self, input: &ZkSolcInput) -> Result<Vec<u8>> {
         let mut cmd = Command::new(&self.zksolc);
 
-        println!("ALLOW PATHS: {:?}", self.allow_paths);
         if !self.allow_paths.is_empty() {
             cmd.arg("--allow-paths");
             cmd.arg(self.allow_paths.iter().map(|p| p.display()).join(","));

--- a/crates/compilers/src/zksync/mod.rs
+++ b/crates/compilers/src/zksync/mod.rs
@@ -13,7 +13,8 @@ use crate::{
     resolver::parse::SolData,
     zksolc::{
         input::{StandardJsonCompilerInput, ZkSolcVersionedInput},
-        ZkSolcCompiler, ZkSolcSettings,
+        settings::ZkSolcSettings,
+        ZkSolcCompiler,
     },
     CompilerInput, Graph, Project, Source,
 };
@@ -72,9 +73,9 @@ pub fn project_standard_json_input(
         .map(|(path, source)| (rebase_path(root, path), source.clone()))
         .collect();
 
-    let mut settings: ZkSolcSettings = project.settings.clone();
+    let mut zk_solc_settings: ZkSolcSettings = project.settings.clone();
     // strip the path to the project root from all remappings
-    settings.remappings = project
+    zk_solc_settings.settings.remappings = project
         .paths
         .remappings
         .clone()
@@ -82,14 +83,15 @@ pub fn project_standard_json_input(
         .map(|r| r.into_relative(project.root()).to_relative_remapping())
         .collect::<Vec<_>>();
 
-    settings.libraries.libs = settings
+    zk_solc_settings.settings.libraries.libs = zk_solc_settings
+        .settings
         .libraries
         .libs
         .into_iter()
         .map(|(f, libs)| (f.strip_prefix(project.root()).unwrap_or(&f).to_path_buf(), libs))
         .collect();
 
-    let input = StandardJsonCompilerInput::new(sources, settings);
+    let input = StandardJsonCompilerInput::new(sources, zk_solc_settings.settings);
 
     Ok(input)
 }


### PR DESCRIPTION
This PR replicates the struct Foundry uses for managing the settings and cli_settings needed for the compilation process. It creates the ZKSettings and ZkSolcSettings and use them accordingly. 