### PR TITLE
chore: Update zksolc to 1.5.2

### DIFF
--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -38,7 +38,7 @@ pub use settings::ZkSolcSettings;
 
 pub const ZKSOLC: &str = "zksolc";
 pub const ZKSYNC_SOLC_RELEASE: Version = Version::new(1, 0, 1);
-pub const ZKSOLC_VERSION: Version = Version::new(1, 5, 1);
+pub const ZKSOLC_VERSION: Version = Version::new(1, 5, 2);
 
 #[derive(Debug, Clone, Serialize)]
 enum ZkSolcOS {


### PR DESCRIPTION
Use latest zksolc version for zk tests