### PR TITLE
feat: Support error / warning suppression in zksolc

### DIFF
--- a/crates/compilers/src/compilers/zksolc/input.rs
+++ b/crates/compilers/src/compilers/zksolc/input.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::HashSet,
-    mem,
     path::{Path, PathBuf},
 };
 
@@ -75,6 +74,9 @@ pub struct ZkSolcInput {
     pub language: SolcLanguage,
     pub sources: Sources,
     pub settings: ZkSettings,
+    // For `zksolc` versions <1.5.7, suppressed warnings / errors were specified on the same level
+    // as `settings`. For `zksolc` 1.5.7+, they are specified inside `settings`. Since we want to
+    // support both options at the time, we duplicate fields from `settings` here.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub suppressed_warnings: HashSet<ZkSolcWarning>,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
@@ -95,9 +97,9 @@ impl Default for ZkSolcInput {
 }
 
 impl ZkSolcInput {
-    fn new(language: SolcLanguage, sources: Sources, mut settings: ZkSettings) -> Self {
-        let suppressed_warnings = mem::take(&mut settings.suppressed_warnings);
-        let suppressed_errors = mem::take(&mut settings.suppressed_errors);
+    fn new(language: SolcLanguage, sources: Sources, settings: ZkSettings) -> Self {
+        let suppressed_warnings = settings.suppressed_warnings.clone();
+        let suppressed_errors = settings.suppressed_errors.clone();
         Self { language, sources, settings, suppressed_warnings, suppressed_errors }
     }
 

--- a/crates/compilers/src/compilers/zksolc/mod.rs
+++ b/crates/compilers/src/compilers/zksolc/mod.rs
@@ -33,8 +33,7 @@ use std::os::unix::fs::PermissionsExt;
 
 pub mod input;
 pub mod settings;
-pub use settings::ZkSettings;
-pub use settings::ZkSolcSettings;
+pub use settings::{ZkSettings, ZkSolcSettings};
 
 pub const ZKSOLC: &str = "zksolc";
 pub const ZKSYNC_SOLC_RELEASE: Version = Version::new(1, 0, 1);

--- a/crates/compilers/src/compilers/zksolc/settings.rs
+++ b/crates/compilers/src/compilers/zksolc/settings.rs
@@ -17,7 +17,6 @@ use std::{
 
 ///
 /// The Solidity compiler codegen.
-///
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Codegen {

--- a/crates/compilers/tests/zksync.rs
+++ b/crates/compilers/tests/zksync.rs
@@ -13,7 +13,7 @@ use foundry_compilers::{
     zksolc::{
         input::ZkSolcInput,
         settings::{ZkSolcError, ZkSolcWarning},
-        ZkSolcCompiler, ZkSolcSettings,
+        ZkSolc, ZkSolcCompiler, ZkSolcSettings,
     },
     zksync::{self, artifact_output::zk::ZkArtifactOutput},
     Graph, ProjectBuilder, ProjectPathsConfig,
@@ -51,13 +51,13 @@ fn zksync_can_compile_dapp_sample() {
     assert_eq!(cache, updated_cache);
 }
 
-#[test]
-fn zksync_can_compile_contract_with_suppressed_errors() {
+fn test_zksync_can_compile_contract_with_suppressed_errors(compiler: ZkSolcCompiler) {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init()
         .ok();
     let mut project = TempProject::<ZkSolcCompiler, ZkArtifactOutput>::dapptools().unwrap();
+    project.project_mut().compiler = compiler;
 
     project
         .add_source(
@@ -87,12 +87,26 @@ fn zksync_can_compile_contract_with_suppressed_errors() {
 }
 
 #[test]
-fn zksync_can_compile_contract_with_suppressed_warnings() {
+fn zksync_can_compile_contract_with_suppressed_errors() {
+    test_zksync_can_compile_contract_with_suppressed_errors(ZkSolcCompiler::default());
+}
+
+#[test]
+fn zksync_pre_1_5_7_can_compile_contract_with_suppressed_errors() {
+    let compiler = ZkSolcCompiler {
+        zksolc: ZkSolc::get_path_for_version(&semver::Version::new(1, 5, 6)).unwrap(),
+        solc: Default::default(),
+    };
+    test_zksync_can_compile_contract_with_suppressed_errors(compiler);
+}
+
+fn test_zksync_can_compile_contract_with_suppressed_warnings(compiler: ZkSolcCompiler) {
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init()
         .ok();
     let mut project = TempProject::<ZkSolcCompiler, ZkArtifactOutput>::dapptools().unwrap();
+    project.project_mut().compiler = compiler;
 
     project
         .add_source(
@@ -136,6 +150,20 @@ fn zksync_can_compile_contract_with_suppressed_warnings() {
         "{:#?}",
         compiled.compiler_output.errors
     );
+}
+
+#[test]
+fn zksync_can_compile_contract_with_suppressed_warnings() {
+    test_zksync_can_compile_contract_with_suppressed_warnings(ZkSolcCompiler::default());
+}
+
+#[test]
+fn zksync_pre_1_5_7_can_compile_contract_with_suppressed_warnings() {
+    let compiler = ZkSolcCompiler {
+        zksolc: ZkSolc::get_path_for_version(&semver::Version::new(1, 5, 6)).unwrap(),
+        solc: Default::default(),
+    };
+    test_zksync_can_compile_contract_with_suppressed_warnings(compiler);
 }
 
 #[test]


### PR DESCRIPTION
- Allows to suppress `zksolc` errors and/or warnings by adding relevant fields to `ZkSettings` and passing them to standard JSON input for the compiler.