### PR TITLE
fix: codeowners in one line

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @nbaztec @elfedy @Karrq @Jrigada
-* @dutterbutter @hedgar2017
+* @nbaztec @elfedy @Karrq @Jrigada @dutterbutter @hedgar2017


### PR DESCRIPTION
The [CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax) explains that patterns can be overridden, thus in our case only the second line is taken into effect, while we would like to have all be matching, I believe.
> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.